### PR TITLE
Fixing path in DSANet Example.jl

### DIFF
--- a/DSANet/Example.jl
+++ b/DSANet/Example.jl
@@ -7,7 +7,7 @@ Pkg.instantiate()
 
 using Flux, Plots, BSON
 using Random
-include("DSAnet.jl")
+include("DSANet.jl")
 include("../data/dataloader.jl")
 
 # Load some sample data


### PR DESCRIPTION
Now using `include("DSANet.jl")` instead of `include("DSAnet.jl")`